### PR TITLE
[ios] Add icon assets generate to the base ios template

### DIFF
--- a/motion/project/template/ios.rb
+++ b/motion/project/template/ios.rb
@@ -32,10 +32,11 @@ App.template = :ios
 require 'motion/project'
 require 'motion/project/template/ios/config'
 require 'motion/project/template/ios/builder'
+require 'motion/project/template/tasks/ios-icon-rule'
 require 'motion/project/repl_launcher'
 
 desc "Build the project, then run the simulator"
-task :default => :simulator
+task :default => ['build:icons', :simulator]
 
 desc "Build everything"
 task :build => ['build:simulator', 'build:device']
@@ -64,17 +65,20 @@ namespace :build do
   end
 
   desc "Build the simulator version"
-  task :simulator do
+  task :simulator => 'build:icons' do
     pre_build_actions('iPhoneSimulator')
     App.build('iPhoneSimulator')
   end
 
   desc "Build the device version"
-  task :device do
+  task :device => 'build:icons' do
     pre_build_actions('iPhoneOS')
     App.build('iPhoneOS')
     App.codesign('iPhoneOS')
   end
+
+  desc "Placeholder task for building the xcassets for the application icon"
+  task :icons
 end
 
 namespace :watch do

--- a/motion/project/template/ios/files/Rakefile.erb
+++ b/motion/project/template/ios/files/Rakefile.erb
@@ -14,6 +14,9 @@ begin
 rescue LoadError
 end
 
+# Uncomment the following line to add an icon generate capacity to your build
+#task 'build:icons' => 'resources/app-icon.icon_asset'
+
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   define_icon_defaults!(app)

--- a/motion/project/template/ios/files/readme.md
+++ b/motion/project/template/ios/files/readme.md
@@ -60,56 +60,43 @@ app.entitlements['beta-reports-active'] = true
 
 As of iOS 11, Apple requires the use of Asset Catalogs for defining
 icons and launch screens. You'll find icon and launch screen templates
-under `./resources/Assets.xcassets`. You can run the following script
-to generate all the icon sizes (once you've specified `1024x1024.png`).
-Keep in mind that your `.png` files _cannot_ contain alpha channels.
+under `./resources/Assets.xcassets`. 
 
-Save this following script to `./gen-icons.sh` and run it:
+The current build has a built-in icon generate that can be triggered 
+from your Rakefile. The first step is to create a PNG file (keep in 
+mind that your `.png` file _cannot_ contain alpha channels) and place 
+it in your `resources` directory. This file should be a minimum of 1024 
+x 1024 pixels (it can be higher) and should be square (to prevent 
+aspect distortion during the generation process).
 
-```sh
-set -x
+To generate your icon in the Asset catalogue, add a dependency to your `Rakefile` as follows:
 
-brew install imagemagick
-
-pushd resources/Assets.xcassets/AppIcon.appiconset/
-
-cp 1024x1024.png "20x20@2x.png"
-cp 1024x1024.png "20x20@3x.png"
-cp 1024x1024.png "29x29@2x.png"
-cp 1024x1024.png "29x29@3x.png"
-cp 1024x1024.png "40x40@2x.png"
-cp 1024x1024.png "40x40@3x.png"
-cp 1024x1024.png "60x60@2x.png"
-cp 1024x1024.png "60x60@3x.png"
-cp 1024x1024.png "20x20~ipad.png"
-cp 1024x1024.png "20x20~ipad@2x.png"
-cp 1024x1024.png "29x29~ipad.png"
-cp 1024x1024.png "29x29~ipad@2x.png"
-cp 1024x1024.png "40x40~ipad.png"
-cp 1024x1024.png "40x40~ipad@2x.png"
-cp 1024x1024.png "76x76~ipad.png"
-cp 1024x1024.png "76x76~ipad@2x.png"
-cp 1024x1024.png "83.5x83.5~ipad@2x.png"
-
-mogrify -resize 40x40 "20x20@2x.png"
-mogrify -resize 60x60 "20x20@3x.png"
-mogrify -resize 58x58 "29x29@2x.png"
-mogrify -resize 87x87 "29x29@3x.png"
-mogrify -resize 80x80 "40x40@2x.png"
-mogrify -resize 120x120 "40x40@3x.png"
-mogrify -resize 120x120 "60x60@2x.png"
-mogrify -resize 180x180 "60x60@3x.png"
-mogrify -resize 20x20 "20x20~ipad.png"
-mogrify -resize 40x40 "20x20~ipad@2x.png"
-mogrify -resize 29x29 "29x29~ipad.png"
-mogrify -resize 58x58 "29x29~ipad@2x.png"
-mogrify -resize 40x40 "40x40~ipad.png"
-mogrify -resize 80x80 "40x40~ipad@2x.png"
-mogrify -resize 76x76 "76x76~ipad.png"
-mogrify -resize 152x152 "76x76~ipad@2x.png"
-mogrify -resize 167x167 "83.5x83.5~ipad@2x.png"
-
-popd
+```ruby
+task :icons => 'resources/app-icon.icon_asset'
 ```
 
+For the above example, the application icon is in a file called `resources/app-icon.png`. The new icons are then generated with the following command:
+
+```sh
+bundle exec rake icons
+```
+Once complete the new set of icon assets (and the `Contents.json` file)
+are generated. Additionally the file `resources/app-icon.icon_asset` will be 
+created (and should be added to git) to track when the generated icons require
+a rebuild (the above command can be run multiple time and will only regenerated
+when the base `.png` is newer than the icon assets).
+
+To make the icon generate part of your regular build process, add then following
+dependency (replacing the previous dependency):
+
+```ruby
+task 'build:icons' => 'resources/app-icon.icon_asset'
+```
+
+Now, the icon assets will be regenerated (if the `resources/app-icon.png` file is newer than the assets) whenever you run any `bundle exec rake` command.
+
 For more information about Asset Catalogs, refer to this link: https://developer.apple.com/library/content/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/
+
+*Note:* For existing projects that do not have the Assets.xcassets directories from the new 
+RubyMotion templates can simply add the `task 'build:icons' ...` dependency from above and 
+all of the necessary files will be generated. 

--- a/motion/project/template/tasks/ios-icon-rule.rb
+++ b/motion/project/template/tasks/ios-icon-rule.rb
@@ -1,0 +1,91 @@
+# encoding: utf-8
+
+# Copyright (c) 2018, Scratchwork Development,
+#                     CANA Software & Services (Andy Stechishin) and contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'json'
+
+IosIconDefinition = Struct.new(:idiom, :size, :scale) do
+  def file_name
+    image_square_string + (idiom == :ipad ? '~ipad' : '') +
+        (scale > 1 ? "@%dx" % scale : "") + ".png"
+  end
+
+  def image_size
+    size * scale
+  end
+
+  def image_square_string
+    size == size.to_i ? "%2dx%2d" % [size, size] : "%2.1fx%2.1f" % [size, size]
+  end
+
+  def image_hash
+    {idiom: idiom, size: image_square_string, filename: file_name, scale: "%dx" % scale}
+  end
+end
+
+rule '.icon_asset' => '.png' do |t|
+  icon_dir = File.dirname(t.source) + '/Assets.xcassets/AppIcon.appiconset'
+  tmp_file = File.dirname(t.source) + '/' + File.basename(t.source, '.png') + '.icon_asset'
+  mkdir_p icon_dir
+
+  Dir.glob(File.join(icon_dir, '*.png')).each { |f| rm f }
+
+  ios_icon_list.each do |icon_defn|
+    sh "sips -Z #{icon_defn.image_size}  #{t.source} --out #{icon_dir}/#{icon_defn.file_name}"
+  end
+
+  File.open(icon_dir + "/Contents.json", 'w') do |f|
+    content_structure = {
+        images: ios_icon_list.map { |icon_defn| icon_defn.image_hash },
+        info: {version: 1, author: 'xcode'}
+    }
+    f << JSON.pretty_generate(content_structure, indent: '  ', space: ' ', space_before: ' ')
+  end
+
+  touch tmp_file
+end
+
+def ios_icon_list
+  [
+      IosIconDefinition.new(:iphone, 20, 2),
+      IosIconDefinition.new(:iphone, 20, 3),
+      IosIconDefinition.new(:iphone, 29, 2),
+      IosIconDefinition.new(:iphone, 29, 3),
+      IosIconDefinition.new(:iphone, 40, 2),
+      IosIconDefinition.new(:iphone, 40, 3),
+      IosIconDefinition.new(:iphone, 60, 2),
+      IosIconDefinition.new(:iphone, 60, 3),
+      IosIconDefinition.new(:ipad, 20, 1),
+      IosIconDefinition.new(:ipad, 20, 2),
+      IosIconDefinition.new(:ipad, 29, 1),
+      IosIconDefinition.new(:ipad, 29, 2),
+      IosIconDefinition.new(:ipad, 40, 1),
+      IosIconDefinition.new(:ipad, 40, 2),
+      IosIconDefinition.new(:ipad, 76, 1),
+      IosIconDefinition.new(:ipad, 76, 2),
+      IosIconDefinition.new(:ipad, 83.5, 2),
+      IosIconDefinition.new('ios-marketing', 1024, 1)
+  ]
+end


### PR DESCRIPTION
Add the tasks directory and the ios-icons-rule.rb file that contains Rake rule to track .icon_asset files to .png, add a require to the ios.rb main Rakefile, update the Rakefile.erb for ios to include a commented out line for the icon generate dependency, update the ios readme.md to include the new icon generate details