### PR TITLE
fix #14 rake device fails for iPhone XS due to new upper case device id

### DIFF
--- a/motion/project/template/ios.rb
+++ b/motion/project/template/ios.rb
@@ -278,8 +278,8 @@ $deployed_app_path = nil
 desc "Deploy on the device"
 task :device => :archive do
   App.info 'Deploy', App.config.archive
-  device_id = (ENV['id'] or App.config.device_id).downcase
-  unless App.config.provisions_all_devices? || App.config.provisioned_devices.include?(device_id)
+  device_id = ENV['id'] || App.config.device_id
+  unless App.config.provisions_all_devices? || (App.config.provisioned_devices & [device_id, device_id.downcase]).any?
     App.fail "Device ID `#{device_id}' not provisioned in profile `#{App.config.provisioning_profile}'"
   end
   env = "XCODE_DIR=\"#{App.config.xcode_dir}\""


### PR DESCRIPTION
It turns out the new ios devices may have a new ID format relying on upppercase letters.

The fix just stops downcasing the device id before it checks that it exists in the provisioning profile and sends it to REPLLauncher.
To prevent breaking the lookup itself, it now checks for either the downcased or the original device id strings.

