### PR TITLE
Remove 76@1~ipad icon

### DIFF
--- a/motion/project/template/tasks/ios-icon-rule.rb
+++ b/motion/project/template/tasks/ios-icon-rule.rb
@@ -83,7 +83,6 @@ def ios_icon_list
       IosIconDefinition.new(:ipad, 29, 2),
       IosIconDefinition.new(:ipad, 40, 1),
       IosIconDefinition.new(:ipad, 40, 2),
-      IosIconDefinition.new(:ipad, 76, 1),
       IosIconDefinition.new(:ipad, 76, 2),
       IosIconDefinition.new(:ipad, 83.5, 2),
       IosIconDefinition.new('ios-marketing', 1024, 1)


### PR DESCRIPTION
Icon 76@1~ipad is no longer necessary on iOS 12.0