### PR TITLE
[osx] Update Rakefile to use local templates directory (under ~/.rubymotion/rubymotion-templates)

### DIFF
--- a/motion/project/template/osx/files/Rakefile.erb
+++ b/motion/project/template/osx/files/Rakefile.erb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
+
 require 'motion/project/template/osx'
 
 begin

--- a/motion/project/template/tvos.rb
+++ b/motion/project/template/tvos.rb
@@ -108,7 +108,7 @@ END
   end
 
   # TODO: Do not hardcode
-  device_name = "Apple TV 1080p"
+  device_name = "Apple TV"
 
   app_bundle = App.config.app_bundle('AppleTVSimulator')
   kernel_path = File.join(App.config.datadir, "AppleTVSimulator", "kernel-x86_64.bc")

--- a/motion/project/template/tvos/files/Rakefile.erb
+++ b/motion/project/template/tvos/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/tvos'
 
 begin


### PR DESCRIPTION
Same as tvOS templates, make OS X templates work with local template updates