### PR TITLE
Check for existence of files before checking mtime

### DIFF
--- a/motion/project/vendor.rb
+++ b/motion/project/vendor.rb
@@ -185,7 +185,7 @@ EOS
       end
 
       build_dir = build_dir(platform)
-      if !File.exist?(build_dir) or Dir.glob('**/*').sort.any? { |x| File.exists?(x) && File.mtime(x) > File.mtime(build_dir) }
+      if !File.exist?(build_dir) or Dir.glob('**/*').sort.any? { |x| File.exist?(x) && File.mtime(x) > File.mtime(build_dir) }
         FileUtils.mkdir_p build_dir
 
         xcodebuild(platform, 'build')

--- a/motion/project/vendor.rb
+++ b/motion/project/vendor.rb
@@ -185,7 +185,7 @@ EOS
       end
 
       build_dir = build_dir(platform)
-      if !File.exist?(build_dir) or Dir.glob('**/*').sort.any? { |x| File.mtime(x) > File.mtime(build_dir) }
+      if !File.exist?(build_dir) or Dir.glob('**/*').sort.any? { |x| File.exists?(x) && File.mtime(x) > File.mtime(build_dir) }
         FileUtils.mkdir_p build_dir
 
         xcodebuild(platform, 'build')


### PR DESCRIPTION
When trying to include the `GA-SDK-IOS` Cocoa pod, I get the following error:

`Errno::ENOENT: No such file or directory @ rb_file_s_mtime - GA-SDK-IOS/GameAnalytics.framework/Resources`

This is because there is no `Resources` directory, even though `GA-SDK-IOS/GameAnalytics.framework/Resources` symlinks to it.  So a `File.mtime(x)` fails.

Now check that it exists before calling `mtime`