### PR TITLE
Multiple `rake clean:all` can sometimes fail

### DIFF
--- a/motion/project/vendor.rb
+++ b/motion/project/vendor.rb
@@ -90,9 +90,11 @@ module Motion; module Project
           end
         end
       end
-      Dir.chdir(@path) do
-        if File.exist?(bridgesupport_build_path)
-          FileUtils.rm bridgesupport_build_path
+      if File.exist?(@path)
+        Dir.chdir(@path) do
+          if File.exist?(bridgesupport_build_path)
+            FileUtils.rm bridgesupport_build_path
+          end
         end
       end
     end


### PR DESCRIPTION
Sometimes doing multiple `rake clean:all` can cause a failure when trying to remove a directory that was previously removed.  Add an extra check that directory exists