### PR TITLE
[osx] Add notarization rake task

### DIFF
--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -51,17 +51,10 @@ namespace :build do
     App.codesign('MacOSX') if App.config_without_setup.codesign_for_release
   end
 
-  desc "Build and notarize the project for release"
-  task :notarize do
-    App.config_without_setup.build_mode = :release
-    App.build('MacOSX')
-    notarizer = Motion::Project::Notarizer.new
-    notarizer.run(App.config, 'MacOSX')
-  end
 end
 
 desc "Build everything"
-task :build => ['build:development', 'build:release', 'build:notarize']
+task :build => ['build:development', 'build:release']
 
 desc "Run the project"
 task :run do
@@ -120,6 +113,30 @@ namespace :archive do
   task :distribution do
     App.config_without_setup.distribution_mode = true
     Rake::Task['archive'].invoke
+  end
+end
+
+desc "Build and notarize the project for release"
+task :notarize do
+  App.config_without_setup.build_mode = :release
+  App.build('MacOSX')
+  notarizer = Motion::Project::Notarizer.new(App.config, 'MacOSX')
+  notarizer.notarize
+end
+
+namespace :notarize do
+  desc "Staple the notarization ticket to your app"
+  task :staple do
+    App.config_without_setup.build_mode = :release
+    notarizer = Motion::Project::Notarizer.new(App.config, 'MacOSX')
+    notarizer.staple
+  end
+
+  desc "List the latest notarization attempts"
+  task :history do
+    App.config_without_setup.build_mode = :release
+    notarizer = Motion::Project::Notarizer.new(App.config, 'MacOSX')
+    notarizer.show_history
   end
 end
 

--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -55,7 +55,6 @@ namespace :build do
   task :notarize do
     App.config_without_setup.build_mode = :release
     App.build('MacOSX')
-    App.codesign('MacOSX') if App.config_without_setup.codesign_for_release
     notarizer = Motion::Project::Notarizer.new
     notarizer.run(App.config, 'MacOSX')
   end

--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -55,6 +55,7 @@ namespace :build do
   task :notarize do
     App.config_without_setup.build_mode = :release
     App.build('MacOSX')
+    App.codesign('MacOSX') if App.config_without_setup.codesign_for_release
     notarizer = Motion::Project::Notarizer.new
     notarizer.run(App.config, 'MacOSX')
   end

--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -31,6 +31,7 @@ App.template = :osx
 require 'motion/project'
 require 'motion/project/template/osx/config'
 require 'motion/project/template/osx/builder'
+require 'motion/project/template/osx/notarizer'
 require 'motion/project/repl_launcher'
 
 desc "Build the project, then run it"
@@ -49,10 +50,18 @@ namespace :build do
     App.build('MacOSX')
     App.codesign('MacOSX') if App.config_without_setup.codesign_for_release
   end
+
+  desc "Build and notarize the project for release"
+  task :notarize do
+    App.config_without_setup.build_mode = :release
+    App.build('MacOSX')
+    notarizer = Motion::Project::Notarizer.new
+    notarizer.run(App.config, 'MacOSX')
+  end
 end
 
 desc "Build everything"
-task :build => ['build:development', 'build:release']
+task :build => ['build:development', 'build:release', 'build:notarize']
 
 desc "Run the project"
 task :run do

--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -33,7 +33,7 @@ module Motion; module Project
     variable :icon, :copyright, :category,
              :embedded_frameworks, :external_frameworks,
              :codesign_for_development, :codesign_for_release,
-             :eval_support, :developer_id
+             :eval_support, :developer_userid, :altool_keychain_item
 
     def initialize(project_dir, build_mode)
       super

--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -33,7 +33,8 @@ module Motion; module Project
     variable :icon, :copyright, :category,
              :embedded_frameworks, :external_frameworks,
              :codesign_for_development, :codesign_for_release,
-             :eval_support, :developer_userid, :developer_app_password
+             :eval_support, :developer_userid, :developer_app_password,
+             :force_deep_sign
 
     def initialize(project_dir, build_mode)
       super

--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -33,7 +33,7 @@ module Motion; module Project
     variable :icon, :copyright, :category,
              :embedded_frameworks, :external_frameworks,
              :codesign_for_development, :codesign_for_release,
-             :eval_support
+             :eval_support, :developer_id
 
     def initialize(project_dir, build_mode)
       super

--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -33,7 +33,7 @@ module Motion; module Project
     variable :icon, :copyright, :category,
              :embedded_frameworks, :external_frameworks,
              :codesign_for_development, :codesign_for_release,
-             :eval_support, :developer_userid, :altool_keychain_item
+             :eval_support, :developer_userid, :developer_app_password
 
     def initialize(project_dir, build_mode)
       super

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -1,0 +1,123 @@
+# encoding: utf-8
+# 
+# MIT License
+# 
+# Copyright (c) 2019 Martin Kolb
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'motion/project/builder'
+
+module Motion; module Project
+  class Notarizer
+
+    attr_accessor :config, :platform, :debug
+
+    def run(config, platform)
+      self.debug = false
+      self.config = config
+      self.platform = platform
+
+      create_entitlements_file
+      codesign
+      check_code_signature
+      zip_app_file
+      notarize
+    end
+
+    private
+
+    def app_bundle
+      @app_bundle ||= File.dirname(self.config.app_bundle(self.platform))
+    end
+
+    def release_zip
+      @release_zip ||= app_bundle.gsub(/\.app$/, '.zip')
+    end
+
+    def bundle_id
+      @bundle_id ||= proc do
+        rv = config.info_plist['CFBundleIdentifier']
+        raise 'Please set app.info_plist[\'CFBundleIdentifier\'] in your Rakefile' if rv.nil?
+        rv
+      end.call
+    end
+
+    def developer_id
+      @developer_id ||= proc do
+        rv = config.developer_id
+        raise 'Please set app.developer_id in your Rakefile' if rv.nil?
+        rv
+      end.call
+    end
+
+    def create_entitlements_file
+      App.info "Creating entitlements.xml file for", app_bundle
+      cmd = "codesign -d --entitlements - #{app_bundle} > entitlements.xml"
+      system cmd
+    end
+
+    def codesign
+      App.info "Deep signing executables for notarization", app_bundle
+
+      cmd = []
+      opts  = "--timestamp  --sign '#{config.codesign_certificate}' -f --verbose=9 "
+      opts += "--deep  --options runtime "
+      opts += "--entitlements entitlements.xml"
+
+      cmd << "find #{app_bundle} -type f -exec codesign #{opts} {} +"
+      cmd << "codesign #{opts} #{app_bundle}"
+
+      sh(cmd)
+    end
+
+    def check_code_signature
+      App.info "Checking code signature… ", app_bundle
+
+      cmd = ["codesign -v --strict --deep --verbose=2 #{app_bundle}"]
+      cmd << "codesign -d --deep --verbose=2 -r- #{app_bundle}"
+      cmd << "spctl --assess -vv #{app_bundle}"
+
+      sh cmd
+    end
+
+    def zip_app_file
+      App.info "Zipping .app file to…", release_zip
+      cmd = "ditto -c -k --keepParent #{app_bundle} #{release_zip}"
+      sh cmd
+    end
+
+    def notarize
+      App.info "Submitting for notarization… ", release_zip
+      cmd  = 'xcrun altool --notarize-app '
+      cmd += "--primary-bundle-id \"#{bundle_id}\" "
+      cmd += "--username \"#{developer_id}\" "
+      cmd += "--password \"@keychain:alttool\" --file #{release_zip}"
+      sh cmd
+    end
+
+    def sh(cmd)
+      cmd = [cmd] unless cmd.is_a? Array
+      cmd.each do |c|
+        puts "\t'#{c}'" if self.debug
+        system c
+      end
+    end
+  end
+end; end

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -1,19 +1,20 @@
-# encoding: utf-8
-# 
+# frozen_string_literal: true
+
+#
 # MIT License
-# 
+#
 # Copyright (c) 2019 Martin Kolb
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,108 +25,139 @@
 
 require 'motion/project/builder'
 
-module Motion; module Project
-  class Notarizer
+module Motion
+  module Project
+    # A class for notarizing osx applications
+    class Notarizer
+      attr_accessor :config, :platform, :debug
 
-    attr_accessor :config, :platform, :debug
+      def run(config, platform)
+        self.debug = false
+        self.config = config
+        self.platform = platform
 
-    def run(config, platform)
-      self.debug = false
-      self.config = config
-      self.platform = platform
+        # Use of additional entitlements file is currently disabled
+        # create_entitlements_file
 
-      create_entitlements_file
-      codesign
-      check_code_signature
-      zip_app_file
-      notarize
-    end
+        codesign
+        check_code_signature
+        zip_app_file
+        notarize
+      end
 
-    private
+      private
 
-    def app_bundle
-      @app_bundle ||= File.dirname(self.config.app_bundle(self.platform))
-    end
+      # The path to the source app bundle which will be notarized
+      def app_bundle
+        @app_bundle ||= File.dirname(config.app_bundle(platform))
+      end
 
-    def release_zip
-      @release_zip ||= app_bundle.gsub(/\.app$/, '.zip')
-    end
+      # The target .zip file which will contain the notarized application bundle
+      def release_zip
+        @release_zip ||= app_bundle.gsub(/\.app$/, '.zip')
+      end
 
-    def bundle_id
-      @bundle_id ||= proc do
-        rv = config.identifier
-        raise 'Please set app.info_plist[\'CFBundleIdentifier\'] in your Rakefile' if rv.nil?
-        rv
-      end.call
-    end
+      # The CFBundleIdentifier from the plist as specified in the Rakefile
+      def bundle_id
+        @bundle_id ||= proc do
+          rv = config.identifier
+          raise 'Please set app.info_plist[\'CFBundleIdentifier\'] in your Rakefile' if rv.nil?
 
-    def developer_userid
-      @developer_userid ||= proc do
-        rv = config.developer_userid
-        raise 'Please set app.developer_userid in your Rakefile' if rv.nil?
-        rv
-      end.call
-    end
+          rv
+        end.call
+      end
 
-    def developer_app_password
-      @developer_app_password ||= proc do
-        rv = config.developer_app_password
-        raise 'Please set app.developer_app_password in your Rakefile!' if rv.nil?
-        rv
-      end.call
-    end
+      # The username of your developer id which is used for notarization
+      def developer_userid
+        @developer_userid ||= proc do
+          rv = config.developer_userid
+          raise 'Please set app.developer_userid in your Rakefile' if rv.nil?
 
-    def create_entitlements_file
-      App.info "Creating entitlements.xml file for", app_bundle
-      cmd = "codesign -d --entitlements - '#{app_bundle}' > entitlements.xml"
-      system cmd
-    end
+          rv
+        end.call
+      end
 
-    def codesign
-      App.info "Deep signing executables for notarization", app_bundle
+      # The password for the specified developer_userid
+      # Use @keychain:<name> for keychain items
+      # or @env:<variable> for environment variables
+      def developer_app_password
+        @developer_app_password ||= proc do
+          rv = config.developer_app_password
+          raise 'Please set app.developer_app_password in your Rakefile! Use @keychain:<name> for keychain items or @env:<variable> for environment variables. See xcrun altool for more help.' if rv.nil?
 
-      cmd = []
-      opts  = "--timestamp  --sign '#{config.codesign_certificate}' -f --verbose=9 "
-      opts += "--deep  --options runtime "
-      opts += "--entitlements entitlements.xml"
+          rv
+        end.call
+      end
 
-      cmd << "find '#{app_bundle}' -type f -exec codesign #{opts} {} +"
-      cmd << "codesign #{opts} '#{app_bundle}'"
+      # This method creates an entitlements.xml file for the app bundle
+      # Currently not in use
+      def create_entitlements_file
+        App.info 'Creating entitlements.xml file for', app_bundle
+        cmd = "codesign -d --entitlements - '#{app_bundle}' > entitlements.xml"
+        system cmd
+      end
 
-      sh(cmd)
-    end
+      # Deep codesign the app bundle for notarization
+      def codesign
+        App.info 'Deep signing executables for notarization', app_bundle
 
-    def check_code_signature
-      App.info "Checking code signature… ", app_bundle
+        cmd = []
+        opts  = "--timestamp  --sign '#{config.codesign_certificate}' -f --verbose=9 "
+        opts += '--deep  --options runtime '
 
-      cmd = ["codesign -v --strict --deep --verbose=2 '#{app_bundle}'"]
-      cmd << "codesign -d --deep --verbose=2 -r- '#{app_bundle}'"
-      cmd << "spctl --assess -vv '#{app_bundle}'"
+        # Use of additional entitlements file is currently disabled
+        # opts += "--entitlements entitlements.xml"
 
-      sh cmd
-    end
+        # Make sure that everything in the bundle is correctly signed
+        # especially 3rd party frameworks
+        # When not doing this notarization may fail e.g. when using
+        # the Sparkle updater CocoaPod (tested with Sparkle pod v1.21)
+        # We could turn this into a optional step (e.g. config.force_deep_sign)
+        cmd << "find '#{app_bundle}' -type f -exec codesign #{opts} {} +"
 
-    def zip_app_file
-      App.info "Zipping .app file to…", release_zip
-      cmd = "ditto -c -k --keepParent '#{app_bundle}' '#{release_zip}'"
-      sh cmd
-    end
+        # Sign the full app bundle
+        cmd << "codesign #{opts} '#{app_bundle}'"
 
-    def notarize
-      App.info "Submitting for notarization… ", release_zip
-      cmd  = 'xcrun altool --notarize-app '
-      cmd += "--primary-bundle-id \"#{bundle_id}\" "
-      cmd += "--username \"#{developer_userid}\" "
-      cmd += "--password \"#{developer_app_password}\" --file '#{release_zip}'"
-      sh cmd
-    end
+        sh(cmd)
+      end
 
-    def sh(cmd)
-      cmd = [cmd] unless cmd.is_a? Array
-      cmd.each do |c|
-        puts "\t'#{c}'" if self.debug
-        system c
+      # Check the code signature of the app bundle in order to be verbose
+      # about errors regarding the signature
+      def check_code_signature
+        App.info 'Checking code signature… ', app_bundle
+
+        cmd = ["codesign -v --strict --deep --verbose=2 '#{app_bundle}'"]
+        cmd << "codesign -d --deep --verbose=2 -r- '#{app_bundle}'"
+        cmd << "spctl --assess -vv '#{app_bundle}'"
+
+        sh cmd
+      end
+
+      # Zip the app into the target zip file
+      def zip_app_file
+        App.info 'Zipping .app file to…', release_zip
+        cmd = "ditto -c -k --keepParent '#{app_bundle}' '#{release_zip}'"
+        sh cmd
+      end
+
+      # Submit the zip file for notarization
+      def notarize
+        App.info 'Submitting for notarization… ', release_zip
+        cmd  = 'xcrun altool --notarize-app '
+        cmd += "--primary-bundle-id \"#{bundle_id}\" "
+        cmd += "--username \"#{developer_userid}\" "
+        cmd += "--password \"#{developer_app_password}\" --file '#{release_zip}'"
+        sh cmd
+      end
+
+      # Helper method for running shell commands
+      def sh(cmd)
+        cmd = [cmd] unless cmd.is_a? Array
+        cmd.each do |c|
+          puts "\t'#{c}'" if debug
+          system c
+        end
       end
     end
   end
-end; end
+end

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -146,8 +146,9 @@ module Motion
         # especially 3rd party frameworks
         # When not doing this notarization may fail e.g. when using
         # the Sparkle updater CocoaPod (tested with Sparkle pod v1.21)
-        # We could turn this into a optional step (e.g. config.force_deep_sign)
-        cmd << "find '#{app_bundle}' -type f -exec codesign #{opts} {} +"
+        if config.force_deep_sign
+          cmd << "find '#{app_bundle}' -type f -exec codesign #{opts} {} +"
+        end
 
         # Sign the full app bundle
         cmd << "codesign #{opts} '#{app_bundle}'"
@@ -187,10 +188,18 @@ Remember to run
 
     rake notarize:staple
 
-after notarization was succesful! To check notarization status run
+after notarization was succesful! 
+To check notarization status run
 
     rake notarize:history
 
+If notarization fails you might want add the following line to your Rakefile:
+
+    Motion::Project::App.setup do |app|
+      ...
+      app.force_deep_sign = true
+      ...
+    end
 S
       end
 

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -67,10 +67,10 @@ module Motion; module Project
       end.call
     end
 
-    def altool_keychain_item
-      @altool_keychain_item ||= proc do
-        rv = config.altool_keychain_item
-        raise 'Please set app.altool_keychain_item in your Rakefile!' if rv.nil?
+    def developer_app_password
+      @developer_app_password ||= proc do
+        rv = config.developer_app_password
+        raise 'Please set app.developer_app_password in your Rakefile!' if rv.nil?
         rv
       end.call
     end
@@ -116,7 +116,7 @@ module Motion; module Project
       cmd  = 'xcrun altool --notarize-app '
       cmd += "--primary-bundle-id \"#{bundle_id}\" "
       cmd += "--username \"#{developer_userid}\" "
-      cmd += "--password \"@keychain:#{altool_keychain_item}\" --file '#{release_zip}'"
+      cmd += "--password \"#{developer_app_password}\" --file '#{release_zip}'"
       sh cmd
     end
 

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -107,7 +107,7 @@ module Motion; module Project
 
     def zip_app_file
       App.info "Zipping .app file to…", release_zip
-      cmd = "ditto -c -k --keepParent '#{app_bundle}' #{release_zip}"
+      cmd = "ditto -c -k --keepParent '#{app_bundle}' '#{release_zip}'"
       sh cmd
     end
 
@@ -116,7 +116,7 @@ module Motion; module Project
       cmd  = 'xcrun altool --notarize-app '
       cmd += "--primary-bundle-id \"#{bundle_id}\" "
       cmd += "--username \"#{developer_userid}\" "
-      cmd += "--password \"@keychain:#{altool_keychain_item}\" --file #{release_zip}"
+      cmd += "--password \"@keychain:#{altool_keychain_item}\" --file '#{release_zip}'"
       sh cmd
     end
 

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,18 @@ Testing out your template before sending a Pull Request (example):
 env RUBYMOTION_TEMPLATES_OVERRIDE=~/projects/rubymotion-templates/motion/project/template/ motion create HelloWorld --template=ios
 ```
 
+Also remember to change the following line in the Rakefile of your test project
+
+```
+$:.unshift("~/.rubymotion/rubymotion-templates")
+```
+
+to
+
+```
+$:.unshift("~/projects/rubymotion-templates")
+```
+
 When you send your PR. Be sure that your commits are in this format (take note of the bracket based tag at the beginning):
 
 ```


### PR DESCRIPTION
As discussed in the motioneers slack channel this gives you three new rake tasks:

1. `rake notarize` to submit your app for notarization
2. `rake notarize:history` to view the status of your recent notarizations
3. `rake staple` to staple and re-zip your application after successful notarization