### PR TITLE
[osx] re-enable notarization entitlements

### DIFF
--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -119,7 +119,6 @@ end
 desc "Build and notarize the project for release"
 task :notarize do
   App.config_without_setup.build_mode = :release
-  App.build('MacOSX')
   notarizer = Motion::Project::Notarizer.new(App.config, 'MacOSX')
   notarizer.notarize
 end

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -39,6 +39,7 @@ module Motion
 
       # Submit the app bundle for notarization
       def notarize
+        check_app_bundle_exist!
         create_entitlements_file
 
         codesign
@@ -172,6 +173,17 @@ module Motion
 
         check_spctl
         puts
+      end
+
+      # Check if the app bundle file exists, otherwise remind the
+      # user to run rake build:release
+      def check_app_bundle_exist!
+        return true if File.exist?(app_bundle)
+
+        show_as_failed("No app bundle found at '#{app_bundle}'! ")
+        puts "Please run \n\n\trake build:release \n\nbefore notarizing!"
+
+        exit(1)
       end
 
       def check_valid_on_disk


### PR DESCRIPTION
I was running into two issues during `rake notarize`:

1. Re-signing the app bundle without using an entitlements file strips any existing entitlements.  So the final file was successfully notarized, but there were not entitlements.

1. After re-enabling the entitlement file creation (which creates it based on the entitlements in the existing app), the additional `App.build('MacOSX')` step in the `rake notarize` task would re-create an unsigned app bundle, which of course doesn't have the entitlements.

   Instead, we now assume that a successful `rake build:release` has been done, the notarize step takes that app and notarizes it.

I also added a couple validations of the resulting `codesign` calls.  Additional checks can be added as needed.