### PR TITLE
[ios] Display list of available and supported SDKs in error message

### DIFF
--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -207,7 +207,9 @@ module Motion; module Project
         unless supported_version && !supported_version.empty?
           App.fail("The requested deployment target SDK " \
                    "is not available or supported by " \
-                   "RubyMotion at this time.")
+                   "RubyMotion at this time.\n" \
+                   "           Available SDKs: #{versions.join(', ')}\n" \
+                   "           Supported SDKs: #{supported_versions.join(', ')}")
         end
         supported_version
       end


### PR DESCRIPTION
This PR adds the list of available and supported SDKs to the "SDK not available" error message. In the case of this error, it is simply trying to find the latest SDK that is supported, so I don't think there is a "target SDK" to display.
<img width="811" alt="Screen Shot 2019-10-17 at 4 55 40 PM" src="https://user-images.githubusercontent.com/446392/67055992-29cae400-f0ff-11e9-850b-d364001eac62.png">

This is what it would look like with multiple SDKs:
![Screen Shot 2019-10-17 at 4 58 57 PM](https://user-images.githubusercontent.com/446392/67056058-7a424180-f0ff-11e9-9ca9-68a146e62445.png)
