### PR TITLE
Add rubymotion-templates directory to Rakefile templates

### DIFF
--- a/motion/project/template/android/files/Rakefile.erb
+++ b/motion/project/template/android/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/android'
 
 begin

--- a/motion/project/template/gem/files/Rakefile.erb
+++ b/motion/project/template/gem/files/Rakefile.erb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
+
 require 'motion/project/template/ios'
 require './lib/<%= name %>'
 

--- a/motion/project/template/ios-action-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-action-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-audio-unit-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-audio-unit-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-broadcast-ui-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-broadcast-ui-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-broadcast-upload-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-broadcast-upload-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-call-directory-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-call-directory-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-content-blocker-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-content-blocker-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension.rb'
 
 begin

--- a/motion/project/template/ios-custom-keyboard-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-custom-keyboard-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension.rb'
 
 begin

--- a/motion/project/template/ios-document-provider-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-document-provider-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-file-provider-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-file-provider-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-framework/files/Rakefile.erb
+++ b/motion/project/template/ios-framework/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-framework'
 
 begin

--- a/motion/project/template/ios-imessage-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-imessage-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-intents-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-intents-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-intents-ui-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-intents-ui-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-notification-content-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-notification-content-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-notification-service-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-notification-service-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-photo-editing-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-photo-editing-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-share-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-share-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-shared-links-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-shared-links-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-spotlight-index-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-spotlight-index-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-today-extension/files/Rakefile.erb
+++ b/motion/project/template/ios-today-extension/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-extension'
 
 begin

--- a/motion/project/template/ios-watch-app/files/Rakefile.erb
+++ b/motion/project/template/ios-watch-app/files/Rakefile.erb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
+$:.unshift("~/.rubymotion/rubymotion-templates")
 require 'motion/project/template/ios-watch-extension'
 
 begin


### PR DESCRIPTION
This PR updates all of the remaining Rakefile templates to add the rubymotion-templates directory to the include path.