### PR TITLE
Resolve bundler deprecation warning

### DIFF
--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -509,7 +509,7 @@ module Motion; module Project
       c_flags = "#{c_flags} -isysroot '#{sdk_path}' #{bridgesupport_cflags} #{includes.join(' ')}"
       cmd = ("RUBYOPT='' '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
       App.info "gen_bridge_metadata", cmd
-      defined?(Bundler) ? Bundler.with_clean_env { sh(cmd) } : sh(cmd)
+      defined?(Bundler) ? Bundler.with_original_env { sh(cmd) } : sh(cmd)
     end
 
     def define_global_env_txt

--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -509,7 +509,11 @@ module Motion; module Project
       c_flags = "#{c_flags} -isysroot '#{sdk_path}' #{bridgesupport_cflags} #{includes.join(' ')}"
       cmd = ("RUBYOPT='' '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
       App.info "gen_bridge_metadata", cmd
-      defined?(Bundler) ? Bundler.with_original_env { sh(cmd) } : sh(cmd)
+      if defined?(Bundler)
+        Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env { sh(cmd) } : Bundler.with_original_env { sh(cmd) }
+      else
+        sh(cmd)
+      end
     end
 
     def define_global_env_txt


### PR DESCRIPTION
Replace `Bundler.with_clean_env` with `Bundler.with_original_env` because it will be deprecated in Bundler 2.1+

also see: https://bundler.io/v2.1/whats_new.html#helper-deprecations  

```  
$ rake simulator
                                                                                                    
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /Library/RubyMotion/lib/motion/project.rb:49)
```