### PR TITLE
Update the default simulators version iPhone 12

### DIFF
--- a/motion/project/template/ios-admob-rewarded-ads/config.rb
+++ b/motion/project/template/ios-admob-rewarded-ads/config.rb
@@ -293,7 +293,7 @@ module Motion; module Project
         if Util::Version.new(xcode_version[0]) < Util::Version.new('7.0')
           ' 6'
         else
-          ' 6s'
+          ' 12'
         end
       end
     end

--- a/motion/project/template/ios/config.rb
+++ b/motion/project/template/ios/config.rb
@@ -314,7 +314,7 @@ module Motion; module Project
         if Util::Version.new(xcode_version[0]) < Util::Version.new('10.0')
           ' 6'
         else
-          ' 8'
+          ' 12'
         end
       end
     end


### PR DESCRIPTION
Currently the default simulator is iPhone 8.
Update to iPhone 12.