### PR TITLE
Update Android archive creation to latest specs

### DIFF
--- a/motion/project/template/android.rb
+++ b/motion/project/template/android.rb
@@ -628,18 +628,19 @@ EOS
       end
     end
 
+    App.info 'Align', archive
+    sh "\"#{App.config.zipalign_path}\" -f 4 \"#{archive}\" \"#{archive}-aligned\""
+    sh "/bin/mv \"#{archive}-aligned\" \"#{archive}\""
+
     App.info 'Sign', archive
     if App.config.development?
-      line = "/usr/bin/jarsigner -digestalg SHA1 -storepass android -keystore \"#{keystore}\" \"#{archive}\" androiddebugkey"
+      line = "\"#{App.config.build_tools_dir}/apksigner\" sign --ks-pass pass:android --ks \"#{keystore}\" --ks-key-alias androiddebugkey \"#{archive}\""
       line << " >& /dev/null" unless Rake.application.options.trace
       sh line
     else
       sh "/usr/bin/jarsigner -sigalg SHA1withRSA -digestalg SHA1 -keystore \"#{keystore}\" \"#{archive}\" \"#{App.config.release_keystore_alias}\""
     end
 
-    App.info 'Align', archive
-    sh "\"#{App.config.zipalign_path}\" -f 4 \"#{archive}\" \"#{archive}-aligned\""
-    sh "/bin/mv \"#{archive}-aligned\" \"#{archive}\""
   end
 
   $bs_files = bs_files

--- a/motion/project/template/android/config.rb
+++ b/motion/project/template/android/config.rb
@@ -264,6 +264,10 @@ module Motion; module Project
       @build_tools_version ||= Motion::Util::Version.new(build_tools_dir.match(/(\d)+\.(\d)+\.(\d)+/))
     end
 
+    def aab_path
+      File.join(versionized_build_dir, name + '.aab')
+    end
+
     def apk_path
       File.join(versionized_build_dir, name + '.apk')
     end


### PR DESCRIPTION
## Sign development APK with Signature Scheme v2

Google now requires APK's to be to be signed with APK Signature Scheme v2(SHA256).
https://developer.android.com/about/versions/nougat/android-7.0.html#apk_signature_v2

If you sign your app using APK Signature Scheme v2 and make further
changes to the app, the app's signature is invalidated. For this reason,
zipalign should be called before signing the APK Signature Scheme v2,
not after.

## Generate an AAB archive for release

From August 2021, new apps are required to publish with the Android App
Bundle on Google Play instead of an APK.
https://developer.android.com/google/play/expansion-files

Running `rake release` now generates an Android App Bundle archive.

Calling `jarsigner` with SHA256withRSA the following error is shown:

      No -tsa or -tsacert is provided and this jar is not timestamped. Without
      a timestamp, users may not be able to validate this jar after the signer
      certificate's expiration date (2046-10-02) or after any future
      revocation date.

Passing the `tsa` option with `http://sha256timestamp.ws.symantec.com/sha256/timestamp`
fixes this error

