### PR TITLE
Fixups to RubyMotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/motion/project/builder.rb
+++ b/motion/project/builder.rb
@@ -197,7 +197,7 @@ module Motion; module Project
           archs.each do |arch|
             # Locate arch kernel.
             kernel = File.join(datadir, platform, "kernel-#{arch}.bc")
-            raise "Can't locate kernel file" unless File.exist?(kernel)
+            raise "Can't locate kernel file #{kernel}" unless File.exist?(kernel)
 
             # Assembly.
             compiler_exec_arch = case arch

--- a/motion/project/template/ios.rb
+++ b/motion/project/template/ios.rb
@@ -231,8 +231,8 @@ END
   at_exit { system("stty echo") } if $stdout.tty? # Just in case the simulator launcher crashes and leaves the terminal without echo.
   Signal.trap(:INT) {} if ENV['debug']
   repl_launcher.launch
-  App.config.print_crash_message if $?.exitstatus != 0 && !App.config.spec_mode
-  exit($?.exitstatus)
+  App.config.print_crash_message if $?.exitstatus.to_i != 0 && !App.config.spec_mode
+  exit($?.exitstatus.to_i)
 end
 
 desc "Create an .ipa archive"

--- a/motion/project/template/ios/config.rb
+++ b/motion/project/template/ios/config.rb
@@ -40,15 +40,19 @@ module Motion; module Project
       App.warn "Unable to determine the version of Mac OS X."
     end
 
+    def xcode_app
+      `xcode-select -p`.strip.sub('/Contents/Developer', '')
+    end
+
     def check_mojave_swift_dylibs
-      return if File.exist?(File.expand_path("/Applications/Xcode.app/Contents/Frameworks/.swift-5-staged"))
+      return if File.exist?(File.expand_path("#{xcode_app}/Contents/Frameworks/.swift-5-staged"))
       ruby_motion_versions = ['6.0', '6.1', '6.2', '6.3']
       macos_versions = ['10.14.4', '10.14.5']
       if ruby_motion_versions.include?(Motion::Version) && macos_versions.include?(macos_version)
         App.warn "Mojave #{macos_version}'s Swift 5 runtime was not found in Xcode (or has not been marked as staged)."
         App.warn "You must run the following commands to fix Xcode (commands may require sudo):"
-        App.warn "    cp -r /usr/lib/swift/*.dylib /Applications/Xcode.app/Contents/Frameworks/"
-        App.warn "    touch /Applications/Xcode.app/Contents/Frameworks/.swift-5-staged"
+        App.warn "    cp -r /usr/lib/swift/*.dylib #{xcode_app}/Contents/Frameworks/"
+        App.warn "    touch #{xcode_app}/Contents/Frameworks/.swift-5-staged"
         App.fail "Rerun build after you have ran the commands above."
       end
     end

--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -669,8 +669,8 @@ S
       includes = ['-I.'] + headers.map { |header| "-I'#{File.dirname(header)}'" }.uniq
       exceptions = exceptions.map { |x| "\"#{x}\"" }.join(' ')
       c_flags = "#{c_flags} -isysroot '#{sdk_path}' #{bridgesupport_cflags} #{includes.join(' ')}"
-      cmd = ("RUBYOPT='' GEM_PATH='' GEM_HOME='' arch -arch x86_64 /usr/bin/ruby '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
-      App.info "gen_bridge_metadata (#{__dir__})", cmd
+      cmd = ("RUBYOPT='' '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
+      App.info "gen_bridge_metadata", cmd
       if defined?(Bundler)
         Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env { sh(cmd) } : Bundler.with_original_env { sh(cmd) }
       else

--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -669,8 +669,8 @@ S
       includes = ['-I.'] + headers.map { |header| "-I'#{File.dirname(header)}'" }.uniq
       exceptions = exceptions.map { |x| "\"#{x}\"" }.join(' ')
       c_flags = "#{c_flags} -isysroot '#{sdk_path}' #{bridgesupport_cflags} #{includes.join(' ')}"
-      cmd = ("RUBYOPT='' '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
-      App.info "gen_bridge_metadata", cmd
+      cmd = ("RUBYOPT='' GEM_PATH='' GEM_HOME='' arch -arch x86_64 /usr/bin/ruby '#{File.join(bindir, 'gen_bridge_metadata')}' #{bridgesupport_flags} --cflags \"#{c_flags}\" --headers \"#{headers_file.path}\" -o '#{bs_file}' #{ "-e #{exceptions}" if exceptions.length != 0}")
+      App.info "gen_bridge_metadata (#{__dir__})", cmd
       if defined?(Bundler)
         Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env { sh(cmd) } : Bundler.with_original_env { sh(cmd) }
       else
@@ -755,15 +755,19 @@ S
       @vendor_projects.delete_if { |x| x.path == path }
     end
 
+    def xcode_app
+      `xcode-select -p`.strip.sub('/Contents/Developer', '')
+    end
+
     def delete_osx_symlink_if_exists
-      if File.exists? "/Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain"
+      if File.exists? "#{xcode_app}/Contents/Developer/Toolchains/OSX10.13.xctoolchain"
         fork do
           begin
-            `rm -rf /Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain`
+            `rm -rf #{xcode_app}/Contents/Developer/Toolchains/OSX10.13.xctoolchain`
           rescue
             puts "RubyMotion attempted to delete the following directory, but wasn't able to."
             puts "Please run the following command manually: "
-            puts 'rm -rf /Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain'
+            puts 'rm -rf #{xcode_app}/Contents/Developer/Toolchains/OSX10.13.xctoolchain'
             puts 'You may need to run the command above with `sudo`.'
             raise
           end


### PR DESCRIPTION
Three / four parts to this.

1. use `xcode-select -p` rather than hard coding path, makes it a lot simpler to try out latest Xcode
2. `exit` doesn't like `nil`

Dropped:
3. reset `GEM_PATH` and `GEM_HOME` because I still use `rvm`
4. explicitly invoke system ruby with `x86_64` arch  when generating bridge metadata