### PR TITLE
Force xml output so that it's compatible when codesign needs it again

### DIFF
--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -147,12 +147,28 @@ module Motion; module Project
     end
 
     def generic_info_plist
+      platform = "MacOSX"
       super.merge({
         'NSHumanReadableCopyright' => copyright,
         'NSPrincipalClass' => 'NSApplication',
         'CFBundleIconFile' => (icon or ''),
         'LSMinimumSystemVersion' => deployment_target,
-        'LSApplicationCategoryType' => (@category.start_with?('public.app-category') ? @category : 'public.app-category.' + @category)
+        'LSApplicationCategoryType' => (@category.start_with?('public.app-category') ? @category : 'public.app-category.' + @category),
+        'DTXcode' => begin
+          vers = xcode_version[0].gsub(/\./, '')
+          if vers.length == 2
+            '0' + vers + '0'
+          else
+            '0' + vers
+          end
+        end,
+        'DTXcodeBuild' => xcode_version[1],
+        'DTSDKName' => "#{platform.downcase}#{sdk_version}",
+        'DTSDKBuild' => sdk_build_version(platform),
+        'DTPlatformName' => platform.downcase,
+        'DTCompiler' => 'com.apple.compilers.llvm.clang.1_0',
+        'DTPlatformVersion' => sdk_version,
+        'DTPlatformBuild' => sdk_build_version(platform)
       })
     end
 

--- a/motion/project/template/osx/notarizer.rb
+++ b/motion/project/template/osx/notarizer.rb
@@ -132,7 +132,7 @@ module Motion
       # Currently not in use
       def create_entitlements_file
         App.info 'Creating entitlements.xml file for', app_bundle
-        cmd = "codesign -d --entitlements - '#{app_bundle}' > '#{entitlements_file}'"
+        cmd = "codesign -d --xml --entitlements - '#{app_bundle}' > '#{entitlements_file}'"
         system cmd
       end
 


### PR DESCRIPTION
If you try to notarize an app, the `create_entitlements_file` generates a file format like

```
[Dict]
	[Key] com.apple.security.app-sandbox
	[Value]
		[Bool] true
	[Key] com.apple.security.device.audio-input
	[Value]
		[Bool] true
	[Key] com.apple.security.device.microphone
	[Value]
		[Bool] true
	[Key] com.apple.security.network.client
	[Value]
		[Bool] true
	[Key] com.apple.security.network.server
	[Value]
		[Bool] true
```

Which is causing codesign invocation in the `codesign` method to fail when using that output in `entitlements.xml`