### PR TITLE
Update reference to deprecated/removed `File.exists?` to use `exist?`

### DIFF
--- a/motion/project/xcode_config.rb
+++ b/motion/project/xcode_config.rb
@@ -756,7 +756,7 @@ S
     end
 
     def delete_osx_symlink_if_exists
-      if File.exists? "/Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain"
+      if File.exist? "/Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain"
         fork do
           begin
             `rm -rf /Applications/Xcode.app/Contents/Developer/Toolchains/OSX10.13.xctoolchain`


### PR DESCRIPTION
The `File.exists?` method (which was previously an alias for `exist?`) was deprecated, then removed. There was only one reference to that method in this project. This PR fixes that.