### PR TITLE
Use notarytool for notarization

### DIFF
--- a/motion/project/template/osx.rb
+++ b/motion/project/template/osx.rb
@@ -124,6 +124,13 @@ task :notarize do
 end
 
 namespace :notarize do
+  desc "Build and notarize the project for release and wait for acceptance"
+  task :wait do
+    App.config_without_setup.build_mode = :release
+    notarizer = Motion::Project::Notarizer.new(App.config, 'MacOSX')
+    notarizer.notarize(true)
+  end
+
   desc "Staple the notarization ticket to your app"
   task :staple do
     App.config_without_setup.build_mode = :release

--- a/motion/project/template/osx/config.rb
+++ b/motion/project/template/osx/config.rb
@@ -33,8 +33,9 @@ module Motion; module Project
     variable :icon, :copyright, :category,
              :embedded_frameworks, :external_frameworks,
              :codesign_for_development, :codesign_for_release,
-             :eval_support, :developer_userid, :developer_app_password,
-             :force_deep_sign
+             :developer_apple_id, :developer_app_password, :developer_team_id,
+             :eval_support, :force_deep_sign,
+             :developer_userid  # deprecated
 
     def initialize(project_dir, build_mode)
       super


### PR DESCRIPTION
Apple has deprecated `altool` for notarizing a macOS app, and will quit working on Oct 1, 2023. See https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool#Save-credentials-in-the-keychain for general migration information.

This migrates to the new `notarytool` command.

A new command, `rake notarize:wait` has been added which will submit the app and _wait_ for Apple to complete the process.  Uses the `--wait` option. The original command, `rake notarize` works the same and returns immediately, where you can then use `rake notarize:history` to check the status..

You must now provide your Team ID in your rake  file using `app.developer_team_id`

