### PR TITLE
Added support to include multiple app icon assets

### DIFF
--- a/motion/project/builder.rb
+++ b/motion/project/builder.rb
@@ -828,7 +828,7 @@ EOS
       else
         app_icon_and_launch_image_options = ''
         if config.respond_to?(:app_icons_asset_bundle) && bundle_name = config.app_icon_name_from_asset_bundle
-          app_icon_and_launch_image_options << " --app-icon '#{bundle_name}'"
+          app_icon_and_launch_image_options << " --app-icon '#{bundle_name}' --include-all-app-icons"
         end
         if config.respond_to?(:launch_images_asset_bundle) && bundle_name = config.launch_image_name_from_asset_bundle
           app_icon_and_launch_image_options << " --launch-image '#{bundle_name}'"


### PR DESCRIPTION
This allows the inclusion of multiple icon assets into the bundle. To make this work, place alternate icons into a folder in the Assets bundle, for example:

```
Assets.xcassets
├── AltIcons
│   ├── AppIconBlack.appiconset
│   │   ├── 1024x1024.png
│   │   ├── 20x20@2x.png
│   │   ├── 20x20@3x.png
│   │   ├── 20x20~ipad.png
│   │   ├── 20x20~ipad@2x.png
│   │   ├── 29x29@2x.png
│   │   ├── 29x29@3x.png
│   │   ├── 29x29~ipad.png
│   │   ├── 29x29~ipad@2x.png
│   │   ├── 40x40@2x.png
│   │   ├── 40x40@3x.png
│   │   ├── 40x40~ipad.png
│   │   ├── 40x40~ipad@2x.png
│   │   ├── 60x60@2x.png
│   │   ├── 60x60@3x.png
│   │   ├── 76x76~ipad@2x.png
│   │   ├── 83.5x83.5~ipad@2x.png
│   │   └── Contents.json
│   ├── AppIconOrange.appiconset
│   │   ├── 1024x1024.png
│   │   ├── 20x20@2x.png
│   │   ├── 20x20@3x.png
│   │   ├── 20x20~ipad.png
│   │   ├── 20x20~ipad@2x.png
│   │   ├── 29x29@2x.png
│   │   ├── 29x29@3x.png
│   │   ├── 29x29~ipad.png
│   │   ├── 29x29~ipad@2x.png
│   │   ├── 40x40@2x.png
│   │   ├── 40x40@3x.png
│   │   ├── 40x40~ipad.png
│   │   ├── 40x40~ipad@2x.png
│   │   ├── 60x60@2x.png
│   │   ├── 60x60@3x.png
│   │   ├── 76x76~ipad@2x.png
│   │   ├── 83.5x83.5~ipad@2x.png
│   │   └── Contents.json
│   ├── AppIconRed.appiconset
│   │   ├── 1024x1024.png
│   │   ├── 20x20@2x.png
│   │   ├── 20x20@3x.png
│   │   ├── 20x20~ipad.png
│   │   ├── 20x20~ipad@2x.png
│   │   ├── 29x29@2x.png
│   │   ├── 29x29@3x.png
│   │   ├── 29x29~ipad.png
│   │   ├── 29x29~ipad@2x.png
│   │   ├── 40x40@2x.png
│   │   ├── 40x40@3x.png
│   │   ├── 40x40~ipad.png
│   │   ├── 40x40~ipad@2x.png
│   │   ├── 60x60@2x.png
│   │   ├── 60x60@3x.png
│   │   ├── 76x76~ipad@2x.png
│   │   ├── 83.5x83.5~ipad@2x.png
│   │   └── Contents.json
│   └── Contents.json
├── AppIcon.appiconset
│   ├── 1024x1024.png
│   ├── 20x20@2x.png
│   ├── 20x20@3x.png
│   ├── 20x20~ipad.png
│   ├── 20x20~ipad@2x.png
│   ├── 29x29@2x.png
│   ├── 29x29@3x.png
│   ├── 29x29~ipad.png
│   ├── 29x29~ipad@2x.png
│   ├── 40x40@2x.png
│   ├── 40x40@3x.png
│   ├── 40x40~ipad.png
│   ├── 40x40~ipad@2x.png
│   ├── 60x60@2x.png
│   ├── 60x60@3x.png
│   ├── 76x76~ipad@2x.png
│   ├── 83.5x83.5~ipad@2x.png
│   └── Contents.json

```


Then at running time icon can be changed via:

`UIApplication.sharedApplication.setAlternateIconName(icon, completionHandler: lambda{|error|})
`
