### PR TITLE
Change the timestamp server to http://timestamp.digicert.com

### DIFF
--- a/motion/project/template/android.rb
+++ b/motion/project/template/android.rb
@@ -675,7 +675,7 @@ EOS
       sh "bundletool build-bundle --modules=\"#{File.join(app_build_dir, 'obj', 'base.zip')}\" --output=\"#{archive}\""
 
       App.info 'Sign', archive
-      sh "/usr/bin/jarsigner -sigalg SHA256withRSA -digestalg SHA-256 -keystore \"#{keystore}\" \"#{archive}\" \"#{App.config.release_keystore_alias}\" -tsa http://sha256timestamp.ws.symantec.com/sha256/timestamp"
+      sh "/usr/bin/jarsigner -sigalg SHA256withRSA -digestalg SHA-256 -keystore \"#{keystore}\" \"#{archive}\" \"#{App.config.release_keystore_alias}\" -tsa http://timestamp.digicert.com"
     end
   end
 


### PR DESCRIPTION
The current timestamp server seems no longer supported resulting in the following error:

      jarsigner: unable to sign jar: java.net.SocketException: Connection reset